### PR TITLE
feature: Implement UI for library and settings tab with placeholder content

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,4 +61,5 @@ dependencies {
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
     implementation("androidx.navigation:navigation-compose:2.5.3")
+    implementation("io.coil-kt:coil-compose:1.3.0")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-
+<uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -14,7 +14,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.Bookish">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/bookish/composables/BottomNavGraph.kt
+++ b/app/src/main/java/com/example/bookish/composables/BottomNavGraph.kt
@@ -1,6 +1,5 @@
 package com.example.bookish.composables
 
-import SettingsScreen
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -8,6 +7,7 @@ import androidx.navigation.compose.composable
 import com.example.bookish.BottomBarScreen
 import com.example.bookish.composables.screens.LibraryScreen
 import com.example.bookish.composables.screens.ListsScreen
+import com.example.bookish.composables.screens.SettingsScreen
 
 @Composable
 fun BottomNavGraph(navController: NavHostController) {

--- a/app/src/main/java/com/example/bookish/composables/BottomNavGraph.kt
+++ b/app/src/main/java/com/example/bookish/composables/BottomNavGraph.kt
@@ -1,5 +1,6 @@
 package com.example.bookish.composables
 
+import SettingsScreen
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -7,7 +8,6 @@ import androidx.navigation.compose.composable
 import com.example.bookish.BottomBarScreen
 import com.example.bookish.composables.screens.LibraryScreen
 import com.example.bookish.composables.screens.ListsScreen
-import com.example.bookish.composables.screens.SettingsScreen
 
 @Composable
 fun BottomNavGraph(navController: NavHostController) {

--- a/app/src/main/java/com/example/bookish/composables/MainScreen.kt
+++ b/app/src/main/java/com/example/bookish/composables/MainScreen.kt
@@ -64,7 +64,9 @@ fun RowScope.AddItem(
             it.route == screen.route
         } == true,
         onClick = {
-            navController.navigate(screen.route)
+            navController.navigate(screen.route) {
+                launchSingleTop = true
+            }
         }
     )
 }

--- a/app/src/main/java/com/example/bookish/composables/components/ItemBookList.kt
+++ b/app/src/main/java/com/example/bookish/composables/components/ItemBookList.kt
@@ -1,0 +1,58 @@
+package com.example.bookish.composables.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberImagePainter
+
+@Composable
+fun ItemBookList() {
+    Card(
+        modifier = Modifier
+            .background(Color.White)
+            .padding(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Start,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Image(
+                painter = rememberImagePainter(data = "https://images.penguinrandomhouse.com/cover/9780593317051"),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(98.dp, 145.dp)
+                    .padding(12.dp)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column {
+                Text(text = "Book Name", color = Color.Black)
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(text = "Author", color = Color.Black)
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ItemBookListPreview() {
+    ItemBookList()
+}

--- a/app/src/main/java/com/example/bookish/composables/components/ItemBookList.kt
+++ b/app/src/main/java/com/example/bookish/composables/components/ItemBookList.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Card
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -23,7 +22,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.rememberImagePainter
 
 @Composable
-fun ItemBookList() {
+fun LibraryItem() {
     Card(
         modifier = Modifier
             .background(Color.White)
@@ -53,6 +52,6 @@ fun ItemBookList() {
 
 @Preview
 @Composable
-fun ItemBookListPreview() {
-    ItemBookList()
+fun LibraryItemPreview() {
+    LibraryItem()
 }

--- a/app/src/main/java/com/example/bookish/composables/screens/Library.kt
+++ b/app/src/main/java/com/example/bookish/composables/screens/Library.kt
@@ -2,7 +2,13 @@ package com.example.bookish.composables.screens
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -10,22 +16,32 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.bookish.R
+import com.example.bookish.composables.components.ItemBookList
 
 @Composable
 fun LibraryScreen() {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.Red),
-        contentAlignment = Alignment.Center
+            .background(Color.White),
     ) {
-        Text(
-            text = stringResource(R.string.library),
-            fontSize = 30.sp,
-            fontWeight = FontWeight.Bold,
-            color = Color.White
-        )
+        Column(modifier = Modifier
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState())) {
+            repeat(30) {
+                ItemBookList()
+                Spacer(modifier = Modifier.height(10.dp))
+            }
+        }
     }
+}
+
+@Preview
+@Composable
+fun LibraryScreenPreview() {
+    LibraryScreen()
 }

--- a/app/src/main/java/com/example/bookish/composables/screens/Library.kt
+++ b/app/src/main/java/com/example/bookish/composables/screens/Library.kt
@@ -9,18 +9,12 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import com.example.bookish.R
-import com.example.bookish.composables.components.ItemBookList
+import com.example.bookish.composables.components.LibraryItem
 
 @Composable
 fun LibraryScreen() {
@@ -33,7 +27,7 @@ fun LibraryScreen() {
             .padding(16.dp)
             .verticalScroll(rememberScrollState())) {
             repeat(30) {
-                ItemBookList()
+                LibraryItem()
                 Spacer(modifier = Modifier.height(10.dp))
             }
         }

--- a/app/src/main/java/com/example/bookish/composables/screens/Settings.kt
+++ b/app/src/main/java/com/example/bookish/composables/screens/Settings.kt
@@ -1,31 +1,121 @@
-package com.example.bookish.composables.screens
-
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.sp
-import com.example.bookish.R
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun SettingsScreen() {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black),
-        contentAlignment = Alignment.Center
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Settings",
+                style = MaterialTheme.typography.h4,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+            Text(
+                text = "Display Settings",
+                style = MaterialTheme.typography.subtitle1,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            DropDownSetting("Font Size", listOf("Small", "Medium", "Large"))
+            SwitchSetting("Theme", true)
+            DropDownSetting("Margin Size", listOf("Small", "Medium", "Large"))
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Text(
+                text = "Reading Preferences",
+                style = MaterialTheme.typography.subtitle1,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            SwitchSetting("Auto Night Mode", true)
+            DropDownSetting("Highlight Color", listOf("Yellow", "Green", "Blue"))
+            DropDownSetting("Reading Progress", listOf("Page Number", "Percentage"))
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Button(
+                onClick = { /* Save settings logic */ },
+                modifier = Modifier.align(Alignment.End)
+            ) {
+                Text(text = "Save")
+            }
+        }
+    }
+}
+
+@Composable
+fun DropDownSetting(name: String, options: List<String>) {
+    var expanded by remember { mutableStateOf(false) }
+    var selectedIndex by remember { mutableStateOf(0) }
+
+    Row(
+        modifier = Modifier.padding(bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(
-            text = stringResource(R.string.settings),
-            fontSize = 30.sp,
-            fontWeight = FontWeight.Bold,
-            color = Color.White
+        Text(text = name, style = MaterialTheme.typography.body1)
+        Spacer(modifier = Modifier.weight(1f))
+        Box(
+            modifier = Modifier.wrapContentSize(),
+            contentAlignment = Alignment.CenterStart
+        ) {
+            TextButton(
+                onClick = { expanded = true }
+            ) {
+                Text(text = options[selectedIndex])
+                Icon(
+                    imageVector = Icons.Default.ArrowDropDown,
+                    contentDescription = "Expand",
+                    modifier = Modifier.padding(start = 4.dp)
+                )
+            }
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false }
+            ) {
+                options.forEachIndexed { index, option ->
+                    DropdownMenuItem(
+                        onClick = {
+                            selectedIndex = index
+                            expanded = false
+                        }
+                    ) {
+                        Text(text = option)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SwitchSetting(name: String, checked: Boolean) {
+    var isChecked by remember { mutableStateOf(checked) }
+
+    Row(
+        modifier = Modifier.padding(bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(text = name, style = MaterialTheme.typography.body1)
+        Spacer(modifier = Modifier.weight(1f))
+        Switch(
+            checked = isChecked,
+            onCheckedChange = { isChecked = it },
+            colors = SwitchDefaults.colors(checkedThumbColor = MaterialTheme.colors.primary)
         )
     }
+}
+@Preview
+@Composable
+fun SettingsScreenPreview() {
+    SettingsScreen()
 }

--- a/app/src/main/java/com/example/bookish/composables/screens/Settings.kt
+++ b/app/src/main/java/com/example/bookish/composables/screens/Settings.kt
@@ -11,37 +11,40 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.example.bookish.R
 
 @Composable
 fun SettingsScreen() {
     Surface(modifier = Modifier.fillMaxSize()) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
-                text = "Settings",
+                text = stringResource(R.string.settings),
                 style = MaterialTheme.typography.h4,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
             Text(
-                text = "Display Settings",
-                style = MaterialTheme.typography.subtitle1,
+                text = stringResource(R.string.display_settings),
+                style = MaterialTheme.typography.h5,
                 modifier = Modifier.padding(bottom = 8.dp)
             )
-            DropDownSetting("Font Size", listOf("Small", "Medium", "Large"))
-            // SwitchSetting("Theme", true)
-            DropDownSetting("Margin Size", listOf("Small", "Medium", "Large"))
+            DropDownSetting(stringResource(R.string.font_size), stringArrayResource(R.array.dropdown_options1))
+            // SwitchSetting(stringResources(R.id.theme), true)
+            DropDownSetting(stringResource(R.string.margin_size), stringArrayResource(R.array.dropdown_options1))
 
             Spacer(modifier = Modifier.height(8.dp))
 
             Text(
-                text = "Reading Preferences",
-                style = MaterialTheme.typography.subtitle1,
+                text = stringResource(R.string.read_preferences),
+                style = MaterialTheme.typography.h5,
                 modifier = Modifier.padding(bottom = 8.dp)
             )
-            SwitchSetting("Auto Night Mode", true)
-            DropDownSetting("Highlight Color", listOf("Yellow", "Green", "Blue"))
-            DropDownSetting("Reading Progress", listOf("Page Number", "Percentage"))
+            // SwitchSetting(stringResource(R.string.auto_night_mode), true)
+            DropDownSetting(stringResource(R.string.highlight), stringArrayResource(R.array.dropdown_options2))
+            DropDownSetting(stringResource(R.string.read_progress), stringArrayResource(R.array.dropdown_options3))
 
             Spacer(modifier = Modifier.weight(1f))
 
@@ -49,14 +52,14 @@ fun SettingsScreen() {
                 onClick = { /* Save settings logic */ },
                 modifier = Modifier.align(Alignment.End)
             ) {
-                Text(text = "Save")
+                Text(text = stringResource(R.string.save))
             }
         }
     }
 }
 
 @Composable
-fun DropDownSetting(name: String, options: List<String>) {
+fun DropDownSetting(name: String, options: Array<String>) {
     var expanded by remember { mutableStateOf(false) }
     var selectedIndex by remember { mutableStateOf(0) }
 
@@ -76,7 +79,7 @@ fun DropDownSetting(name: String, options: List<String>) {
                 Text(text = options[selectedIndex])
                 Icon(
                     imageVector = Icons.Default.ArrowDropDown,
-                    contentDescription = "Expand",
+                    contentDescription = stringResource(R.string.expand),
                     modifier = Modifier.padding(start = 4.dp)
                 )
             }

--- a/app/src/main/java/com/example/bookish/composables/screens/Settings.kt
+++ b/app/src/main/java/com/example/bookish/composables/screens/Settings.kt
@@ -1,3 +1,5 @@
+package com.example.bookish.composables.screens
+
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
@@ -27,10 +29,10 @@ fun SettingsScreen() {
                 modifier = Modifier.padding(bottom = 8.dp)
             )
             DropDownSetting("Font Size", listOf("Small", "Medium", "Large"))
-            SwitchSetting("Theme", true)
+            // SwitchSetting("Theme", true)
             DropDownSetting("Margin Size", listOf("Small", "Medium", "Large"))
 
-            Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier.height(8.dp))
 
             Text(
                 text = "Reading Preferences",

--- a/app/src/main/java/com/example/bookish/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/bookish/ui/theme/Theme.kt
@@ -6,12 +6,6 @@ import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 
-private val DarkColorPalette = darkColors(
-    primary = Purple200,
-    primaryVariant = Purple700,
-    secondary = Teal200
-)
-
 private val LightColorPalette = lightColors(
     primary = Purple500,
     primaryVariant = Purple700,
@@ -29,11 +23,7 @@ private val LightColorPalette = lightColors(
 
 @Composable
 fun BookishTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
-    val colors = if (darkTheme) {
-        DarkColorPalette
-    } else {
-        LightColorPalette
-    }
+    val colors = LightColorPalette
 
     MaterialTheme(
         colors = colors,

--- a/app/src/main/java/com/example/bookish/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/bookish/ui/theme/Theme.kt
@@ -2,7 +2,6 @@ package com.example.bookish.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Bookish</string>
     <string name="library">Library</string>
     <string name="lists">Lists</string>
     <string name="settings">Settings</string>
     <string name="nav_icon">Navigation Icon</string>
+    <string name="save">Save</string>
+    <string name="expand">Expand</string>
+    <string name="auto_night_mode">Auto Night Mode</string>
+    <string name="highlight">Highlight Color</string>
+    <string name="read_progress">Reading Progress</string>
+    <string name="read_preferences">Reading Preferences</string>
+    <string name="display_settings">Display Settings</string>
+    <string name="font_size">Font Size</string>
+    <string name="margin_size">Margin Size</string>
+    <string name="theme">Theme</string>
+    <string-array name="dropdown_options1">
+        <item>Small</item>
+        <item>Medium</item>
+        <item>Large</item>
+    </string-array>
+    <string-array name="dropdown_options2">
+        <item>Yellow</item>
+        <item>Green</item>
+        <item>Blue</item>
+    </string-array>
+    <string-array name="dropdown_options3">
+        <item>Page Number</item>
+        <item>Percentage</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
Implemented list of books and settings Composables for future reuse when we actually will add real books. 

- For book list: used Coil to download the book cover from remote address
- Settings tab: added some basic settings for a book reader. For now they don't do anything. Utilized switches and dropdowns for better User eXperience
- Used Preview functions to waste less time on building the app every time you wanna check the UI

## Screenshots:
### Library tab:
![image](https://github.com/AKushch1337/Bookish/assets/89732075/601dfda2-8ed3-4051-bc44-d89bb7c71d25)
### Settings tab:
![image](https://github.com/AKushch1337/Bookish/assets/89732075/d6599dfe-c48a-439d-820a-d8ffacea055f)
### Dropdown menu:
![image](https://github.com/AKushch1337/Bookish/assets/89732075/8a0fe185-0d4f-48f4-950c-023d937eda57)
### Switch:
![image](https://github.com/AKushch1337/Bookish/assets/89732075/d898fca4-98f7-46ea-ba63-6e94f807f4ee)
